### PR TITLE
Add support for OSX aarch64

### DIFF
--- a/root_cgo_darwin.go
+++ b/root_cgo_darwin.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build cgo,darwin,!arm,!arm64,!ios
+// +build cgo,darwin,!ios
 
 package syscerts
 

--- a/root_darwin_armx.go
+++ b/root_darwin_armx.go
@@ -5,7 +5,7 @@
 // license that can be found in the LICENSE file.
 
 // +build cgo
-// +build darwin,ios
+// +build ios
 
 package syscerts
 

--- a/root_darwin_armx.go
+++ b/root_darwin_armx.go
@@ -5,8 +5,7 @@
 // license that can be found in the LICENSE file.
 
 // +build cgo
-// +build darwin
-// +build arm arm64 ios
+// +build darwin,ios
 
 package syscerts
 


### PR DESCRIPTION
Go 1.16 adds support of 64-bit ARM architecture on macOS (also known as Apple Silicon) with GOOS=darwin, GOARCH=arm64. Like the darwin/amd64 port, the darwin/arm64 port supports cgo, internal and external linking, c-archive, c-shared, and pie build modes, and the race detector.

The iOS port, which was previously darwin/arm64, has been renamed to ios/arm64. GOOS=ios implies the darwin build tag, just as GOOS=android implies the linux build tag. This change should be transparent to anyone using gomobile to build iOS apps.

Note that this patch is only working for Go >= 1.16